### PR TITLE
Bindings for associated images

### DIFF
--- a/examples/convenience.rs
+++ b/examples/convenience.rs
@@ -18,7 +18,7 @@ fn basic_usage(
     println!("Downsample factor at level 0: {}", os.get_level_downsample(0)?);
     println!("Best level for downsampling factor 4.5: {}", os.get_best_level_for_downsample(4.5)?);
 
-    let im = os.read_region(1500, 1000, 0, 512, 512)?;
+    let im = os.read_region(1500 as u64, 1000 as u64, 0, 512, 512)?;
     im.save("/tmp/wsi_region_2.png")?;
 
     println!("\nPrint properties from the dictionary");
@@ -27,6 +27,11 @@ fn basic_usage(
     }
     println!("\nPrint available properties using the properties module");
     os.properties.print_available();
+
+    let associated_images = os.get_associated_images()?;
+    for (name, img) in &associated_images {
+        img.save(format!("/tmp/associated_image_{}.png", name))?;
+    }
 
     Ok(())
 }

--- a/examples/raw_bindings.rs
+++ b/examples/raw_bindings.rs
@@ -12,44 +12,46 @@ fn basic_usage(
     filename: &str
 ) -> Result<(), Error> {
 
-    let vendor = bindings::detect_vendor(filename)?;
-    println!("Vendor: {}", vendor);
+    unsafe {
+        let vendor = bindings::detect_vendor(filename)?;
+        println!("Vendor: {}", vendor);
 
-    let osr = bindings::open(filename)?;
+        let osr = bindings::open(filename)?;
 
-    let levels = bindings::get_level_count(osr)?;
-    println!("Slide has {} levels", levels);
+        let levels = bindings::get_level_count(osr)?;
+        println!("Slide has {} levels", levels);
 
-    let (height, width) = bindings::get_level0_dimensions(osr)?;
-    println!("Slide has dimension {} x {} at level 0", height, width);
+        let (height, width) = bindings::get_level0_dimensions(osr)?;
+        println!("Slide has dimension {} x {} at level 0", height, width);
 
-    let level = 0;
-    let (height, width) = bindings::get_level_dimensions(osr, level)?;
-    println!("Slide has dimension {} x {} at level {}", height, width, level);
+        let level = 0;
+        let (height, width) = bindings::get_level_dimensions(osr, level)?;
+        println!("Slide has dimension {} x {} at level {}", height, width, level);
 
-    let factor = bindings::get_level_downsample(osr, level)?;
-    println!("Slide at level {} is downsampled with factor {}", level, factor);
+        let factor = bindings::get_level_downsample(osr, level)?;
+        println!("Slide at level {} is downsampled with factor {}", level, factor);
 
-    let downsample_factor = 5.6;
-    let level = bindings::get_best_level_for_downsample(osr, downsample_factor)?;
-    println!("Best level for downsample factor {} is {}", downsample_factor, level);
+        let downsample_factor = 5.6;
+        let level = bindings::get_best_level_for_downsample(osr, downsample_factor)?;
+        println!("Best level for downsample factor {} is {}", downsample_factor, level);
 
-    let x = 1000;
-    let y = 1500;
-    let level = 0;
-    let h = 512;
-    let w = 512;
-    let word_repr = utils::WordRepresentation::BigEndian;
-    let buffer = bindings::read_region(osr, x, y, level, w, h)?;
-    let im = utils::decode_buffer(&buffer, h as u32, w as u32, word_repr)?;
-    im.save(Path::new("/tmp/wsi_region_1.png"))?;
-    println!("Region is written");
+        let x = 1000;
+        let y = 1500;
+        let level = 0;
+        let h = 512;
+        let w = 512;
+        let word_repr = utils::WordRepresentation::BigEndian;
+        let buffer = bindings::read_region(osr, x, y, level, w, h)?;
+        let im = utils::decode_buffer(&buffer, h as u32, w as u32, word_repr)?;
+        im.save(Path::new("/tmp/wsi_region_1.png"))?;
+        println!("Region is written");
 
-    // Test error
-    //let factor = bindings::get_level_downsample(osr, 2)?;
-    //println!("{:?}", bindings::get_error(osr));
+        // Test error
+        //let factor = bindings::get_level_downsample(osr, 2)?;
+        //println!("{:?}", bindings::get_error(osr));
 
-    bindings::close(osr);
+        bindings::close(osr);
+    }
 
     Ok(())
 }
@@ -61,11 +63,38 @@ fn properties(
 
     println!("Slide in {} has the following properties:", filename);
     println!("{0:<40} {1}", "Property key", "Property value");
-    for name in bindings::get_property_names(osr)? {
-        println!("{0:<40} {1}", name, bindings::get_property_value(osr, &name)?);
-    }
+    unsafe {
+        for name in bindings::get_property_names(osr)? {
+            println!("{0:<40} {1}", name, bindings::get_property_value(osr, &name)?);
+        }
 
-    bindings::close(osr);
+        bindings::close(osr);
+    }
+    Ok(())
+}
+
+
+fn associated_images(
+    filename: &str
+) -> Result<(), Error> {
+    let osr = bindings::open(filename)?;
+
+    println!("Slide in {} has the following associated images:", filename);
+    unsafe {
+        for name in bindings::get_associated_image_names(osr)? {
+            println!("{0:<40}", name);
+            let (width, height) = bindings::get_associated_image_dimensions(osr, &name)?;
+            println!("Associated image '{}' has dimension {} x {}", name, width, height);
+            let word_repr = utils::WordRepresentation::BigEndian;
+            let buffer = bindings::read_associated_image(osr, &name)?;
+            let im = utils::decode_buffer(&buffer, height as u32, width as u32, word_repr)?;
+            let dist_path = format!("/tmp/associated_image_{}.png", name);
+            im.save(Path::new(&dist_path))?;
+            println!("Associated image '{}' is written", name);
+        }
+
+        bindings::close(osr);
+    }
     Ok(())
 }
 
@@ -85,6 +114,14 @@ fn main() {
         Ok(_) => println!("Property functions are working okay"),
         Err(msg) => {
             println!("Property functions not working");
+            println!("{}", msg);
+        },
+    }
+
+    match associated_images(filename) {
+        Ok(_) => println!("Associated image functions are working okay"),
+        Err(msg) => {
+            println!("Associated image functions not working");
             println!("{}", msg);
         },
     }

--- a/src/convenience.rs
+++ b/src/convenience.rs
@@ -376,4 +376,21 @@ impl OpenSlide {
         }
         Ok(())
     }
+
+    /// Get associated images with the current slide
+    pub fn get_associated_images(&self) -> Result<HashMap<String, RgbaImage>, Error> {
+        let mut associated_images = HashMap::<String, RgbaImage>::new();
+        for name in unsafe { bindings::get_associated_image_names(self.osr)? } {
+            let (width, height) = unsafe {
+                bindings::get_associated_image_dimensions(self.osr, &name)?
+            };
+            let word_repr = utils::WordRepresentation::BigEndian;
+            let buffer = unsafe {
+                bindings::read_associated_image(self.osr, &name)?
+            };
+            let img = utils::decode_buffer(&buffer, height as u32, width as u32, word_repr)?;
+            associated_images.insert(name.clone(), img);
+        }
+        Ok(associated_images)
+    }
 }


### PR DESCRIPTION
Hi.
Thanks for contributing!

This adds bindings for associated images (which are label images, macro images, etc...).
Following openslide-functions are added:
- const char *const * openslide_get_associated_image_names (openslide_t *osr)
- void openslide_get_associated_image_dimensions (openslide_t *osr, const char *name, int64_t *w, int64_t *h)
- void openslide_read_associated_image (openslide_t *osr, const char *name, uint32_t *dest)

I also added convenient functions `get_associated_images` mimicking python-bindings `OpenSlide.associated_images`.

Example sources are modified reflecting this change.
I added `unsafe` block to compile `examples/raw_bindings.rs` on rustc 1.36 which may be unnecessary to your environment.

I'm new to rust so this change may have some mistakes (format, etc) and any advice is welcome!!